### PR TITLE
Add  pandoc and texlive-latex-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     python3 python3-pip python3-dev curl postgresql-client libnss3 libnspr4 \
     libatk1.0-0 libatk-bridge2.0-0 libcups2 libatspi2.0-0 libxcomposite1 nodejs \
     libportaudio2 libasound-dev libreoffice unoconv poppler-utils chromium chromium-sandbox \
-    unixodbc unixodbc-dev cmake openscad xvfb xauth && \
+    unixodbc unixodbc-dev cmake openscad xvfb xauth \
+    pandoc texlive-latex-base && \
     apt-get install -y gcc-10 g++-10 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
@@ -33,6 +34,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     apt-get build-dep sqlite3 -y && \
     rm -rf /var/lib/apt/lists/*
+
 
 # Install SQLite3
 RUN wget https://www.sqlite.org/2023/sqlite-autoconf-3420000.tar.gz && \


### PR DESCRIPTION
This is part of the bounty Add Commands to Convert Markdown to docx, xlsx, and pdf in the AGiXT Repo.