### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,6 @@
 name: Build and Test
+permissions:
+  contents: read
 
 on: ["push"]
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/Josh-XT/aicontainer/security/code-scanning/1](https://github.com/Josh-XT/aicontainer/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to limit the default GITHUB_TOKEN permissions used by this workflow. Since this workflow only delegates to a reusable workflow and doesn’t obviously need write access itself, a safe minimal default is `contents: read`, which matches GitHub’s recommended baseline for read-only access. More granular permissions, if needed by the called workflow, should be defined either here or within `docker.yml`, but we can’t edit that file based on the prompt.

The single best change, without altering existing functionality, is to add a top-level `permissions` block right under the `name:` (or `on:`) key in `.github/workflows/build-and-test.yml`. This will apply to all jobs (including the `build` job that calls `docker.yml`) unless overridden per job. We will set `contents: read`, which is generally sufficient for checking out code and many read-only operations. If the reusable workflow later needs additional scopes, they can be added there; our change simply establishes a safe baseline. No imports or external libraries are needed—this is a pure YAML configuration update.

Concretely:
- Edit `.github/workflows/build-and-test.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after the `name: Build and Test` line (line 1) and before the `on:` block. No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
