### PR TITLE
fix: update GitPython to address security vulnerabilities

### DIFF
--- a/static-requirements.txt
+++ b/static-requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.12.3
 docx2txt==0.8
-GitPython==3.1.43
+GitPython==3.1.47
 pdfplumber==0.11.4
 playwright==1.58.0
 pandas==2.2.3


### PR DESCRIPTION
## Summary
- Update GitPython from 3.1.43 to 3.1.47 in static-requirements.txt.
- Addresses GHSA-x2qx-6953-8485 and GHSA-rpm5-65cw-6hj4 by using the patched GitPython release.

## Validation
- Verified the dependency pin change in static-requirements.txt.